### PR TITLE
feat: Integrate personal rules into coding-plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code plugin for structured development workflow",
-    "version": "1.0.4"
+    "version": "1.1.0"
   },
   "plugins": [
     {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Coding Plugin v1.0.4
+# Coding Plugin v1.1.0
 
 **Build apps with AI, even if you can't code.**
 
@@ -127,6 +127,8 @@ That's it. Two commands.
 |---------|-------------|
 | `/code:plan-issue <feature>` | Research codebase, create GitHub issue with phases |
 | `/code:implement #<number>` | Execute phases from issue (runs until complete) |
+| `/code:commit` | Generate conventional commit from staged changes |
+| `/code:pr` | Create GitHub PR with auto-generated description |
 | `/code:handover` | Save session state (optional - auto-managed) |
 | `/code:continue` | Resume from handover |
 | `/code:simplify` | Clean up code after implementation |
@@ -269,6 +271,19 @@ claude-files/
 ```
 
 To restore: `cp -r claude-files/* ~/.claude/`
+
+---
+
+## Optional: Frontend Stack Rules
+
+For frontend projects using Bun/Shadcn/TypeScript, add this to your project's `CLAUDE.md`:
+
+```markdown
+# Frontend Stack Rules
+@coding-plugin/rules/frontend.md
+```
+
+Or copy the content directly from `coding-plugin/rules/frontend.md` into your project's `CLAUDE.md`.
 
 ---
 

--- a/coding-plugin/.claude-plugin/plugin.json
+++ b/coding-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "coding-plugin",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Phased coding workflow with auto-phase management. plan-issue → implement (spawns subagents per phase, auto-handover at 55% context).",
   "author": {
     "name": "Kennet Kusk"

--- a/coding-plugin/agents/implementer.md
+++ b/coding-plugin/agents/implementer.md
@@ -71,6 +71,15 @@ Only mark phase complete when:
 3. **Small commits** - Atomic, descriptive commits per task
 4. **Update checkboxes** - Keep issue in sync (after verification)
 
+## 🔀 Git & Terminal Rules
+
+- **No Heredocs:** NEVER use `cat <<EOF` - fails silently. Use `Write` tool instead.
+- **Temp Files:** Use `.claude-*` prefix (`.claude-commit-msg.txt`, `.claude-pr-body.md`)
+- **Diffs:** Always use `--` separator: `git diff -- file.ts`
+- **Commit Format:** `<emoji> <type>: <subject>`
+  - ✨ feat | 🐛 fix | ♻️ refactor | 📝 docs | 🧪 test | 🔧 config
+- **Smart Commit:** Use `Skill("coding-plugin:commit")` for auto-generated messages
+
 ## Constraints
 
 - **NEVER mark [x] without passing tests**

--- a/coding-plugin/commands/commit.md
+++ b/coding-plugin/commands/commit.md
@@ -1,0 +1,80 @@
+---
+allowed-tools: Bash(git:*), Write
+description: Generate conventional commit from staged changes
+---
+
+# Smart Commit
+
+Generate a conventional commit message from staged changes.
+
+## Step 1: Check Staged Changes
+
+```bash
+git status --short
+git diff --cached --stat
+```
+
+If nothing staged → Tell user to stage changes first (`git add`).
+
+## Step 2: Analyze Changes
+
+Read the staged diff:
+```bash
+git diff --cached
+```
+
+Determine:
+- Type: feat/fix/refactor/docs/test/config
+- Scope: affected area (optional)
+- Summary: what changed and why
+
+## Step 3: Check Recent History
+
+```bash
+git log -5 --oneline
+```
+
+Match the project's commit style.
+
+## Step 4: Generate Commit
+
+Format: `<emoji> <type>: <subject>`
+
+| Emoji | Type | Use for |
+|-------|------|---------|
+| ✨ | feat | New features |
+| 🐛 | fix | Bug fixes |
+| ♻️ | refactor | Code restructuring |
+| 📝 | docs | Documentation |
+| 🧪 | test | Tests |
+| 🔧 | config | Configuration |
+
+## Step 5: Execute Commit
+
+**Short message (< 50 chars):**
+```bash
+git commit -m "✨ feat: add user authentication"
+```
+
+**Long message (multi-line):**
+1. Write to `.claude-commit-msg.txt`:
+   ```
+   ✨ feat: add user authentication
+
+   - Add login/logout endpoints
+   - Implement JWT token handling
+   - Add auth middleware
+
+   Closes #123
+   ```
+2. Commit with file:
+   ```bash
+   git commit -F .claude-commit-msg.txt
+   ```
+
+## Rules
+
+- **No heredocs** - Always use Write tool + `-F` flag for long messages
+- **Atomic commits** - One logical change per commit
+- **Present tense** - "add feature" not "added feature"
+- **No period** - Subject line doesn't end with period

--- a/coding-plugin/commands/implement.md
+++ b/coding-plugin/commands/implement.md
@@ -126,6 +126,7 @@ For the current phase:
 - Branch: `feature/<issue-number>-<short-desc>` (if not already on it)
 - Commits: Small, atomic, descriptive
 - Format: `✨ <description>` for features, `🐛 <description>` for fixes
+- **Smart Commit:** Use `/commit` for auto-generated conventional commits
 
 ## Step 4: Update Issue
 

--- a/coding-plugin/commands/plan-issue.md
+++ b/coding-plugin/commands/plan-issue.md
@@ -352,4 +352,12 @@ When creating phases, aim for ~55% context usage per phase:
 - Enables auto-handover without mid-phase interruption
 - If a phase is too large, split into sub-phases
 
+## Next Steps
+
+After branch is created, implement with `/implement #<number>`.
+
+**Git Commands Available:**
+- `/commit` - Auto-generate conventional commit from staged changes
+- `/pr` - Create PR with auto-generated description
+
 Output issue URL for `/code/implement #<number>`.

--- a/coding-plugin/commands/pr.md
+++ b/coding-plugin/commands/pr.md
@@ -1,0 +1,77 @@
+---
+allowed-tools: Bash(gh:*), Bash(git:*), Write
+description: Create GitHub PR with auto-generated description
+---
+
+# Create Pull Request
+
+Create a PR with auto-generated description from branch commits.
+
+## Step 1: Check Branch State
+
+```bash
+git branch --show-current
+git status --short
+```
+
+If uncommitted changes → Warn user to commit first.
+If on main/master → Warn user to create feature branch.
+
+## Step 2: Get Branch Diff
+
+```bash
+git log main..HEAD --oneline
+git diff main...HEAD --stat
+```
+
+Identify:
+- All commits on this branch
+- Files changed
+- Purpose of the changes
+
+## Step 3: Generate PR Description
+
+Format:
+```markdown
+## Summary
+[1-2 sentences describing what this PR does]
+
+## Changes
+- [Bullet points of key changes]
+
+## Testing
+- [ ] Tests pass
+- [ ] Manual testing done
+
+---
+Created with `/code:pr`
+```
+
+## Step 4: Write Description to File
+
+**CRITICAL:** Never use heredocs. Always write to file first.
+
+Write description to `.claude-pr-body.md` using Write tool.
+
+## Step 5: Create PR
+
+```bash
+gh pr create --title "<type>: <summary>" --body-file .claude-pr-body.md
+```
+
+Title format matches commit convention:
+- `feat: add user authentication`
+- `fix: resolve login redirect loop`
+
+## Step 6: Output Result
+
+Show:
+- PR URL
+- Title
+- Target branch (usually main)
+
+## Rules
+
+- **No heredocs** - Always use `--body-file`
+- **Check for uncommitted changes** - Warn if dirty working tree
+- **Don't force push** - Let user handle that manually

--- a/coding-plugin/rules/frontend.md
+++ b/coding-plugin/rules/frontend.md
@@ -1,0 +1,55 @@
+# Frontend Stack Rules
+
+> Add to your project's `CLAUDE.md` to enable: `@coding-plugin/rules/frontend.md`
+
+## Stack (Non-Negotiable)
+
+- **Framework:** React or Next.js
+- **Package manager:** Bun (never npm/yarn)
+- **Components:** Shadcn UI only
+- **Language:** TypeScript (never JavaScript)
+- **Styling:** Tailwind via Shadcn conventions
+
+## Shadcn Setup
+
+```bash
+bunx shadcn@latest init
+bunx shadcn@latest add button card dialog ...
+```
+
+Reference: https://ui.shadcn.com/
+
+## Component Rules
+
+- Use Shadcn components before building custom
+- Follow Shadcn color tokens (`--primary`, `--secondary`, etc.)
+- Use Shadcn font conventions (Inter default)
+- Import from `@/components/ui/*`
+
+| Need | Use |
+|------|-----|
+| Buttons | `<Button variant="...">` |
+| Forms | Shadcn Form + react-hook-form |
+| Modals | `<Dialog>` |
+| Lists | `<Card>` or `<Table>` |
+| Feedback | `<Toast>` via sonner |
+
+## File Structure
+
+```
+src/
+  components/
+    ui/          # Shadcn components (don't edit)
+    custom/      # Your components
+  app/           # Next.js app router
+  lib/
+    utils.ts     # cn() helper
+```
+
+## Flags
+
+- ❗ Using npm/yarn instead of Bun
+- ❗ Custom component when Shadcn has one
+- ❗ Inline styles instead of Tailwind
+- ❗ JavaScript files (.js/.jsx)
+- ❗ UI code in Python project


### PR DESCRIPTION
## Summary
Add Git workflow rules, frontend stack rules, and /commit + /pr commands.

Closes #11

## Changes
- Add 🔀 Git & Terminal Rules to implementer agent
- Create opt-in `frontend.md` (Bun/Shadcn/TypeScript)
- Add `/commit` command (conventional commits)
- Add `/pr` command (auto-generated PR description)
- Update README with new commands + frontend rules section
- Bump version to 1.1.0

---
Created with `/code:pr`