### PR TITLE
Add Bun 1.3, GCP safety rules and deployment commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code plugin for task-driven development workflow",
-    "version": "2.4.1"
+    "version": "2.5.0"
   },
   "plugins": [
     {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Coding Plugin v2.4.1
+# Coding Plugin v2.5.0
 
 **Build apps with AI, even if you can't code.**
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,106 @@ Refactor CLAUDE.md and LESSONS.md for progressive disclosure. Keeps context file
 
 ---
 
+### `/code:bun-init <project-name>`
+
+Initialize a new Bun + Next.js + Shadcn/UI project with GCP Cloud Run deployment setup.
+
+```bash
+/code:bun-init my-app
+```
+
+**Creates:**
+
+- Bun 1.3.8 runtime with Next.js 14+ App Router
+- Shadcn/UI components (button, card, input, form, dialog, toast, table)
+- TypeScript + Tailwind CSS
+- Dockerfile optimized for GCP Cloud Run
+- docker-compose.yml for local development
+- Bun test runner setup
+
+---
+
+### `/code:bun-deploy-staging`
+
+Deploy current project to GCP Cloud Run staging environment.
+
+```bash
+/code:bun-deploy-staging
+```
+
+**Requires `.env.example` or `.env.staging` with:**
+
+- `GCP_PROJECT_STAGING` - GCP project ID
+- `GCP_REGION` - Deployment region (default: europe-west1)
+- `SERVICE_NAME` - Cloud Run service name
+
+**Staging config:** 1 CPU, 512Mi memory, 0-3 instances, unauthenticated access.
+
+---
+
+### `/code:bun-deploy-production yes`
+
+Deploy to GCP Cloud Run production. Requires explicit "yes" confirmation.
+
+```bash
+/code:bun-deploy-production yes
+```
+
+**Safety checks:**
+
+- Staging must be deployed first
+- Tests must pass
+- Explicit "yes" argument required
+
+**Production config:** 2 CPU, 1Gi memory, 1-10 instances, authenticated access, CPU boost.
+
+---
+
+### `/code:settings-audit`
+
+Analyze project and generate appropriate `.claude/settings.json` permissions.
+
+```bash
+/code:settings-audit
+```
+
+**Detects and recommends permissions for:**
+
+- Bun/Node projects (`bun:*`, `bunx:*`, `npm:*`)
+- Docker projects (`docker:*`, `docker-compose:*`)
+- GCP projects (`gcloud:*`, `gsutil:*`)
+- Python projects (`uv:*`, `pip:*`, `python:*`)
+
+**Also flags:** Sensitive files that should be in `.gitignore` and `.claudeignore`.
+
+---
+
+## Rules
+
+The plugin includes rules that provide patterns and guardrails.
+
+### `bun-native.md`
+
+Bun 1.3+ native API patterns. Prefer these over npm packages:
+
+| Instead of            | Use Bun Native                      |
+| --------------------- | ----------------------------------- |
+| `pg` / `postgres`     | `import { sql } from "bun:sql"`     |
+| `ioredis` / `redis`   | `import { redis } from "bun:redis"` |
+| `@aws-sdk/client-s3`  | `import { S3 } from "bun:s3"`       |
+| `express` / `fastify` | `Bun.serve()`                       |
+
+### `gcp-safety.md`
+
+GCP resource protection rules:
+
+- **Never delete** Cloud Run services, SQL instances, GCS buckets without explicit approval
+- **Require "yes"** for production deployments
+- **Start small** with resource sizing (staging: 1 CPU/512Mi, production: 2 CPU/1Gi)
+- **Separate environments** by project ID (`*-staging` vs `*-prod`)
+
+---
+
 ## Architecture
 
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ A Claude Code plugin that turns your ideas into working software through a task-
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────────────────┐
+│   Project Setup (once per project):                                                  │
+│                                                                                      │
+│   /code:bun-init my-app  →  /code:settings-audit                                     │
+│         │                         │                                                  │
+│         ▼                         ▼                                                  │
+│   Create Bun + Next.js       Generate .claude/settings.json                          │
+│   + Shadcn + Docker          with detected permissions                               │
+│                                                                                      │
+├──────────────────────────────────────────────────────────────────────────────────────┤
+│   Feature Development (repeat per feature):                                          │
 │                                                                                      │
 │   /plan  →  /code:interview  →  /code:plan-issue  →  /clear  →  /code:implement  →  /code:finalizer
 │     │            │                    │                              │                    │
@@ -20,7 +30,16 @@ A Claude Code plugin that turns your ideas into working software through a task-
 │                                         ▼                         ▼                      ▼
 │                                   Output: #42              Auto-compact at 70%     Close issue
 │                                   (ctrl+t to view)         No manual handover      Delete branch
-│                                                                                         │
+│                                                                                      │
+├──────────────────────────────────────────────────────────────────────────────────────┤
+│   Deployment (after features merged):                                                │
+│                                                                                      │
+│   /code:bun-deploy-staging  →  test  →  /code:bun-deploy-production yes              │
+│            │                              │                                          │
+│            ▼                              ▼                                          │
+│   Deploy to GCP staging            Deploy to production                              │
+│   (1 CPU, 512Mi, 0-3 inst)         (requires "yes", tests must pass)                 │
+│                                                                                      │
 ├──────────────────────────────────────────────────────────────────────────────────────┤
 │   Maintenance (run periodically):                                                    │
 │                                                                                      │
@@ -36,33 +55,65 @@ A Claude Code plugin that turns your ideas into working software through a task-
 └──────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
-### Example
+### Example: Full Lifecycle
 
 ```bash
-# 1. Explore your idea
+# ══════════════════════════════════════════════════════════
+# PROJECT SETUP (once)
+# ══════════════════════════════════════════════════════════
+
+# 1. Create new project
+/code:bun-init my-saas-app
+# → Creates Bun + Next.js + Shadcn + Docker setup
+
+# 2. Generate permissions
+cd my-saas-app
+/code:settings-audit
+# → Creates .claude/settings.json with detected tools
+
+# ══════════════════════════════════════════════════════════
+# FEATURE DEVELOPMENT (repeat per feature)
+# ══════════════════════════════════════════════════════════
+
+# 3. Explore your idea
 /plan (shift-tab) add dark mode toggle to the app
 
-# 2. (Optional) Clarify requirements
+# 4. (Optional) Clarify requirements
 /code:interview
 # → Answers questions, updates plan with details
 
-# 3. Create GitHub issue with tasks
+# 5. Create GitHub issue with tasks
 /code:plan-issue add dark mode toggle
 # → Issue #42 created
 
-# 4. Clear context before implementing
+# 6. Clear context before implementing
 /clear
 
-# 5. Run implementation (orchestrator handles everything)
+# 7. Run implementation (orchestrator handles everything)
 /code:implement #42
 
-# 6. Finalize when complete
-
+# 8. Finalize when complete
 /code:finalizer         # Merge directly to main
 # or
 /code:finalizer --pr    # Create PR for review
 
-# 7. (Periodic) Update project knowledge
+# ══════════════════════════════════════════════════════════
+# DEPLOYMENT (after features merged)
+# ══════════════════════════════════════════════════════════
+
+# 9. Deploy to staging
+/code:bun-deploy-staging
+# → Builds and deploys to GCP Cloud Run staging
+
+# 10. Test staging, then deploy to production
+/code:bun-deploy-production yes
+# → Requires "yes", verifies tests pass first
+
+# ══════════════════════════════════════════════════════════
+# MAINTENANCE (periodic)
+# ══════════════════════════════════════════════════════════
+
+# 11. Update project knowledge
 /code:lessons           # Analyze commits, update LESSONS.md
 /code:cleanup           # Refactor context files
 ```
@@ -130,7 +181,35 @@ Restart Claude Code after installation.
 
 ## Commands
 
-### `/code:interview [plan-file]`
+### Project Setup
+
+#### `/code:bun-init <project-name>`
+
+Initialize a new Bun + Next.js + Shadcn/UI project with GCP Cloud Run deployment setup.
+
+```bash
+/code:bun-init my-app
+```
+
+**Creates:** Bun 1.3.8 + Next.js 14+ + Shadcn/UI + TypeScript + Tailwind + Docker + Bun test runner.
+
+---
+
+#### `/code:settings-audit`
+
+Analyze project and generate `.claude/settings.json` permissions.
+
+```bash
+/code:settings-audit
+```
+
+**Detects:** Bun/Node, Docker, GCP, Python projects and recommends appropriate tool permissions.
+
+---
+
+### Feature Development
+
+#### `/code:interview [plan-file]`
 
 Deep requirement clarification through structured questioning. Use between `/plan` and `/code:plan-issue`.
 
@@ -151,7 +230,7 @@ Deep requirement clarification through structured questioning. Use between `/pla
 
 ---
 
-### `/code:plan-issue <feature>`
+#### `/code:plan-issue <feature>`
 
 Research codebase and create GitHub issue with task manifest.
 
@@ -164,7 +243,7 @@ Research codebase and create GitHub issue with task manifest.
 
 ---
 
-### `/code:implement #<issue-number>`
+#### `/code:implement #<issue-number>`
 
 Launch orchestrator to execute all tasks from the issue.
 
@@ -186,7 +265,7 @@ Launch orchestrator to execute all tasks from the issue.
 
 ---
 
-### `/code:finalizer [--pr] [issue-number]`
+#### `/code:finalizer [--pr] [issue-number]`
 
 Finalize feature: merge or create PR, close issue, cleanup.
 
@@ -205,7 +284,36 @@ Finalize feature: merge or create PR, close issue, cleanup.
 
 ---
 
-### `/code:commit`
+### Deployment
+
+#### `/code:bun-deploy-staging`
+
+Deploy to GCP Cloud Run staging environment.
+
+```bash
+/code:bun-deploy-staging
+```
+
+**Config:** 1 CPU, 512Mi, 0-3 instances, unauthenticated. Requires `GCP_PROJECT_STAGING`, `GCP_REGION`, `SERVICE_NAME` in `.env`.
+
+---
+
+#### `/code:bun-deploy-production yes`
+
+Deploy to GCP Cloud Run production. Requires explicit "yes" confirmation.
+
+```bash
+/code:bun-deploy-production yes
+```
+
+**Safety:** Staging must exist, tests must pass, explicit "yes" required.
+**Config:** 2 CPU, 1Gi, 1-10 instances, authenticated, CPU boost.
+
+---
+
+### Utility
+
+#### `/code:commit`
 
 Generate conventional commit from staged changes.
 
@@ -215,7 +323,7 @@ Generate conventional commit from staged changes.
 
 ---
 
-### `/code:pr`
+#### `/code:pr`
 
 Create GitHub PR with auto-generated description.
 
@@ -225,7 +333,7 @@ Create GitHub PR with auto-generated description.
 
 ---
 
-### `/code:simplify`
+#### `/code:simplify`
 
 Analyze code for simplification opportunities and bugs.
 
@@ -236,7 +344,9 @@ Analyze code for simplification opportunities and bugs.
 
 ---
 
-### `/code:lessons [N]`
+### Maintenance
+
+#### `/code:lessons [N]`
 
 Analyze recent commits and update LESSONS.md with patterns.
 
@@ -247,7 +357,7 @@ Analyze recent commits and update LESSONS.md with patterns.
 
 ---
 
-### `/code:cleanup`
+#### `/code:cleanup`
 
 Refactor CLAUDE.md and LESSONS.md for progressive disclosure. Keeps context files lean and contradiction-free.
 
@@ -266,80 +376,6 @@ Refactor CLAUDE.md and LESSONS.md for progressive disclosure. Keeps context file
 7. Archives LESSONS.md content (never deletes)
 
 **Output:** Summary showing before/after line counts and changes made.
-
----
-
-### `/code:bun-init <project-name>`
-
-Initialize a new Bun + Next.js + Shadcn/UI project with GCP Cloud Run deployment setup.
-
-```bash
-/code:bun-init my-app
-```
-
-**Creates:**
-
-- Bun 1.3.8 runtime with Next.js 14+ App Router
-- Shadcn/UI components (button, card, input, form, dialog, toast, table)
-- TypeScript + Tailwind CSS
-- Dockerfile optimized for GCP Cloud Run
-- docker-compose.yml for local development
-- Bun test runner setup
-
----
-
-### `/code:bun-deploy-staging`
-
-Deploy current project to GCP Cloud Run staging environment.
-
-```bash
-/code:bun-deploy-staging
-```
-
-**Requires `.env.example` or `.env.staging` with:**
-
-- `GCP_PROJECT_STAGING` - GCP project ID
-- `GCP_REGION` - Deployment region (default: europe-west1)
-- `SERVICE_NAME` - Cloud Run service name
-
-**Staging config:** 1 CPU, 512Mi memory, 0-3 instances, unauthenticated access.
-
----
-
-### `/code:bun-deploy-production yes`
-
-Deploy to GCP Cloud Run production. Requires explicit "yes" confirmation.
-
-```bash
-/code:bun-deploy-production yes
-```
-
-**Safety checks:**
-
-- Staging must be deployed first
-- Tests must pass
-- Explicit "yes" argument required
-
-**Production config:** 2 CPU, 1Gi memory, 1-10 instances, authenticated access, CPU boost.
-
----
-
-### `/code:settings-audit`
-
-Analyze project and generate appropriate `.claude/settings.json` permissions.
-
-```bash
-/code:settings-audit
-```
-
-**Detects and recommends permissions for:**
-
-- Bun/Node projects (`bun:*`, `bunx:*`, `npm:*`)
-- Docker projects (`docker:*`, `docker-compose:*`)
-- GCP projects (`gcloud:*`, `gsutil:*`)
-- Python projects (`uv:*`, `pip:*`, `python:*`)
-
-**Also flags:** Sensitive files that should be in `.gitignore` and `.claudeignore`.
 
 ---
 
@@ -410,7 +446,8 @@ Tasks without dependencies run in parallel. Blocked tasks wait for their depende
 - **Keep scope small** — One feature at a time
 - **Trust the process** — Tests run automatically, failures get fixed
 - **Run `/code:lessons` periodically** — Builds project knowledge
-- **Use `/init` in new projects** — Creates CLAUDE.md with project context
+- **Use `/code:bun-init` for new projects** — Creates full Bun + Next.js + GCP setup
+- **Use `/code:settings-audit`** — Auto-generates permissions for your project
 
 ---
 

--- a/coding-plugin/.claude-plugin/plugin.json
+++ b/coding-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "coding-plugin",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Task-driven coding workflow with native Task tools. plan-issue → implement (orchestrator spawns implementer per task, ctrl+t progress view).",
   "author": {
     "name": "Kennet Kusk"

--- a/coding-plugin/commands/bun-deploy-production.md
+++ b/coding-plugin/commands/bun-deploy-production.md
@@ -1,0 +1,122 @@
+---
+allowed-tools: Bash(gcloud:*), Bash(docker:*), Read
+description: Deploy to GCP Cloud Run production (requires "yes" confirmation)
+argument-hint: [yes]
+---
+
+# Deploy to Production
+
+Deploy current project to GCP Cloud Run production environment.
+
+## ⚠️ Production Safety
+
+**This command requires explicit "yes" confirmation.**
+
+```bash
+CONFIRM="$ARGUMENTS"
+if [ "$CONFIRM" != "yes" ]; then
+  echo "❌ Production deployment requires explicit confirmation"
+  echo ""
+  echo "Usage: /code:bun-deploy-production yes"
+  echo ""
+  echo "This will deploy to PRODUCTION. Make sure:"
+  echo "  ✅ Staging deployment tested"
+  echo "  ✅ All tests passing"
+  echo "  ✅ Version bumped"
+  exit 1
+fi
+```
+
+## Step 1: Pre-deployment Checks
+
+```bash
+# Verify staging was deployed first
+echo "🔍 Checking staging deployment..."
+gcloud run services describe $SERVICE_NAME \
+  --project $GCP_PROJECT_STAGING \
+  --region $GCP_REGION \
+  --format "value(status.url)" 2>/dev/null || {
+    echo "❌ Error: Deploy to staging first"
+    exit 1
+  }
+
+# Verify tests pass
+echo "🧪 Running tests..."
+bun test || {
+  echo "❌ Error: Tests failed. Fix before deploying to production."
+  exit 1
+}
+```
+
+## Step 2: Load Configuration
+
+Read `.env.example` or `.env.production` for:
+
+- `GCP_PROJECT_PRODUCTION` - GCP project ID
+- `GCP_REGION` - Deployment region
+- `SERVICE_NAME` - Cloud Run service name
+
+## Step 3: Build Container
+
+```bash
+# Build with Cloud Build
+gcloud builds submit \
+  --project $GCP_PROJECT_PRODUCTION \
+  --tag gcr.io/$GCP_PROJECT_PRODUCTION/$SERVICE_NAME
+```
+
+## Step 4: Deploy to Cloud Run
+
+```bash
+gcloud run deploy $SERVICE_NAME \
+  --project $GCP_PROJECT_PRODUCTION \
+  --image gcr.io/$GCP_PROJECT_PRODUCTION/$SERVICE_NAME \
+  --platform managed \
+  --region $GCP_REGION \
+  --no-allow-unauthenticated \
+  --cpu 2 \
+  --memory 1Gi \
+  --min-instances 1 \
+  --max-instances 10 \
+  --port 8080 \
+  --cpu-boost \
+  --session-affinity
+```
+
+## Step 5: Verify Deployment
+
+```bash
+# Get service URL
+SERVICE_URL=$(gcloud run services describe $SERVICE_NAME \
+  --project $GCP_PROJECT_PRODUCTION \
+  --region $GCP_REGION \
+  --format "value(status.url)")
+
+echo "🚀 Production URL: $SERVICE_URL"
+
+# Check revision
+gcloud run revisions list \
+  --project $GCP_PROJECT_PRODUCTION \
+  --service $SERVICE_NAME \
+  --region $GCP_REGION \
+  --limit 3
+```
+
+## Output
+
+Report:
+
+- 🚀 Production URL
+- 📊 Resource allocation (2 CPU, 1Gi)
+- 🔄 Active revision
+- 📈 Traffic split (if gradual rollout)
+
+## Rules
+
+- **Requires "yes" argument** - No silent deployments
+- **Staging first** - Must have staging deployment
+- **Tests must pass** - No broken deployments
+- Production uses more resources (2 CPU, 1Gi)
+- Auth required (no-allow-unauthenticated)
+- Min instances = 1 for fast cold starts
+- CPU boost enabled for startup performance

--- a/coding-plugin/commands/bun-deploy-staging.md
+++ b/coding-plugin/commands/bun-deploy-staging.md
@@ -1,0 +1,90 @@
+---
+allowed-tools: Bash(gcloud:*), Bash(docker:*), Read
+description: Deploy to GCP Cloud Run staging environment
+---
+
+# Deploy to Staging
+
+Deploy current project to GCP Cloud Run staging environment.
+
+## Step 1: Verify Environment
+
+```bash
+# Check for required files
+if [ ! -f "Dockerfile" ]; then
+  echo "❌ Error: Dockerfile not found"
+  exit 1
+fi
+
+if [ ! -f ".env.example" ]; then
+  echo "⚠️ Warning: .env.example not found"
+fi
+```
+
+## Step 2: Load Configuration
+
+Read `.env.example` or `.env.staging` for:
+
+- `GCP_PROJECT_STAGING` - GCP project ID
+- `GCP_REGION` - Deployment region (default: europe-west1)
+- `SERVICE_NAME` - Cloud Run service name
+
+```bash
+# Verify gcloud is configured
+gcloud config get-value project
+gcloud config get-value account
+```
+
+## Step 3: Build Container
+
+```bash
+# Build with Cloud Build (recommended)
+gcloud builds submit --tag gcr.io/$GCP_PROJECT_STAGING/$SERVICE_NAME
+
+# Or build locally and push
+docker build -t gcr.io/$GCP_PROJECT_STAGING/$SERVICE_NAME .
+docker push gcr.io/$GCP_PROJECT_STAGING/$SERVICE_NAME
+```
+
+## Step 4: Deploy to Cloud Run
+
+```bash
+gcloud run deploy $SERVICE_NAME \
+  --image gcr.io/$GCP_PROJECT_STAGING/$SERVICE_NAME \
+  --platform managed \
+  --region $GCP_REGION \
+  --allow-unauthenticated \
+  --cpu 1 \
+  --memory 512Mi \
+  --min-instances 0 \
+  --max-instances 3 \
+  --port 8080
+```
+
+## Step 5: Verify Deployment
+
+```bash
+# Get service URL
+gcloud run services describe $SERVICE_NAME \
+  --region $GCP_REGION \
+  --format "value(status.url)"
+
+# Check service status
+gcloud run services list --filter="SERVICE:$SERVICE_NAME"
+```
+
+## Output
+
+Report:
+
+- ✅ Service URL
+- 📊 Resource allocation (CPU, memory)
+- 🔄 Revision name
+- ⏱️ Deployment time
+
+## Rules
+
+- Staging uses minimal resources (1 CPU, 512Mi)
+- Allow unauthenticated for easier testing
+- Min instances = 0 to save costs
+- Always verify deployment succeeded

--- a/coding-plugin/commands/bun-init.md
+++ b/coding-plugin/commands/bun-init.md
@@ -1,0 +1,152 @@
+---
+context: fork
+allowed-tools: Bash(bun:*), Bash(bunx:*), Bash(mkdir:*), Bash(git:*), Write, Read
+description: Initialize a new Bun + Next.js + Shadcn/UI project with GCP Cloud Run deployment setup
+argument-hint: <project-name>
+---
+
+# Initialize Bun + Next.js + Shadcn/UI Project
+
+Project: $ARGUMENTS
+
+Creates a new full-stack project with:
+
+- Bun 1.3.8 runtime
+- Next.js 14+ with App Router
+- Shadcn/UI components
+- TypeScript
+- Tailwind CSS
+- Docker setup for GCP Cloud Run
+- Testing with Bun's test runner
+
+## Step 1: Validate Arguments
+
+```bash
+PROJECT_NAME="$ARGUMENTS"
+if [ -z "$PROJECT_NAME" ]; then
+  echo "❌ Error: Project name required"
+  echo "Usage: /code:bun-init <project-name>"
+  exit 1
+fi
+
+if [ -d "$PROJECT_NAME" ]; then
+  echo "❌ Error: Directory '$PROJECT_NAME' already exists"
+  exit 1
+fi
+```
+
+## Step 2: Create Next.js Project
+
+```bash
+bun create next-app $PROJECT_NAME --typescript --tailwind --eslint --app --src-dir --import-alias "@/*"
+```
+
+## Step 3: Initialize Shadcn/UI
+
+```bash
+cd $PROJECT_NAME
+bunx shadcn@latest init -y
+```
+
+## Step 4: Add Common Components
+
+```bash
+cd $PROJECT_NAME
+bunx shadcn@latest add button card input form dialog toast table -y
+```
+
+## Step 5: Add Test Dependencies
+
+```bash
+cd $PROJECT_NAME
+bun add -d @testing-library/react @testing-library/jest-dom happy-dom
+```
+
+## Step 6: Create Dockerfile
+
+Write `Dockerfile` with Bun 1.3.8:
+
+```dockerfile
+FROM oven/bun:1.3.8-alpine AS deps
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+FROM oven/bun:1.3.8-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN bun run build
+
+FROM oven/bun:1.3.8-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production PORT=8080 HOSTNAME="0.0.0.0"
+RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+USER nextjs
+EXPOSE 8080
+CMD ["bun", "run", "server.js"]
+```
+
+## Step 7: Create docker-compose.yml
+
+```yaml
+version: "3.8"
+services:
+  app:
+    build: .
+    ports:
+      - "3000:8080"
+    environment:
+      - NODE_ENV=development
+```
+
+## Step 8: Create .env.example
+
+```bash
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+GCP_PROJECT_STAGING=your-staging-project
+GCP_PROJECT_PRODUCTION=your-production-project
+GCP_REGION=europe-west1
+SERVICE_NAME=your-service-name
+```
+
+## Step 9: Update next.config.ts
+
+Ensure standalone output for Docker:
+
+```typescript
+import type { NextConfig } from "next";
+const nextConfig: NextConfig = { output: "standalone" };
+export default nextConfig;
+```
+
+## Step 10: Create Example Test
+
+Create `__tests__/example.test.ts`:
+
+```typescript
+import { describe, it, expect } from "bun:test";
+describe("Example", () => {
+  it("works", () => expect(1 + 1).toBe(2));
+});
+```
+
+## Done
+
+Project initialized! Next steps:
+
+```bash
+cd $PROJECT_NAME
+bun run dev        # Start development
+bun test           # Run tests
+docker-compose up  # Test Docker build
+```
+
+Deploy with:
+
+- `/code:bun-deploy-staging` - Deploy to staging
+- `/code:bun-deploy-production` - Deploy to production (requires "yes")

--- a/coding-plugin/commands/settings-audit.md
+++ b/coding-plugin/commands/settings-audit.md
@@ -1,0 +1,150 @@
+---
+allowed-tools: Read, Write, Bash(git:*)
+description: Generate .claude/settings.json permissions from project analysis
+---
+
+# Settings Audit
+
+Analyze project and generate appropriate `.claude/settings.json` permissions.
+
+## Step 1: Analyze Project
+
+Detect project type and required tools:
+
+```bash
+# Check for package managers and tools
+ls -la package.json bun.lock yarn.lock pnpm-lock.yaml Cargo.toml pyproject.toml go.mod 2>/dev/null
+
+# Check for Docker
+ls -la Dockerfile docker-compose.yml 2>/dev/null
+
+# Check for cloud configs
+ls -la .gcloudignore cloudbuild.yaml fly.toml vercel.json 2>/dev/null
+```
+
+## Step 2: Read Existing Settings
+
+```bash
+if [ -f ".claude/settings.json" ]; then
+  cat .claude/settings.json
+else
+  echo "No existing settings found"
+fi
+```
+
+## Step 3: Generate Permissions
+
+Based on project analysis, recommend permissions:
+
+### Base Permissions (All Projects)
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(git:*)", "Read", "Write", "Edit"]
+  }
+}
+```
+
+### Bun/Node Projects
+
+Add if `package.json` or `bun.lock` exists:
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(bun:*)", "Bash(bunx:*)", "Bash(npm:*)", "Bash(npx:*)"]
+  }
+}
+```
+
+### Docker Projects
+
+Add if `Dockerfile` exists:
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(docker:*)", "Bash(docker-compose:*)"]
+  }
+}
+```
+
+### GCP Projects
+
+Add if `.gcloudignore` or `cloudbuild.yaml` exists:
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(gcloud:*)", "Bash(gsutil:*)"]
+  }
+}
+```
+
+### Python Projects
+
+Add if `pyproject.toml` or `requirements.txt` exists:
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(uv:*)", "Bash(pip:*)", "Bash(python:*)", "Bash(pytest:*)"]
+  }
+}
+```
+
+## Step 4: Check for Sensitive Patterns
+
+Flag if found:
+
+- `.env` files with secrets
+- `credentials.json` or service account keys
+- API keys in source files
+
+Recommend adding to `.gitignore` and `.claudeignore`.
+
+## Step 5: Generate Settings File
+
+Write `.claude/settings.json` with:
+
+1. Detected permissions
+2. Plans directory (if not set)
+3. Environment variables for task management
+
+Example output:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(bun:*)",
+      "Bash(bunx:*)",
+      "Bash(docker:*)",
+      "Bash(gcloud:*)"
+    ],
+    "deny": []
+  },
+  "plansDirectory": "plans",
+  "env": {
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "70"
+  }
+}
+```
+
+## Output
+
+Report:
+
+- 📁 Project type detected
+- ✅ Permissions recommended
+- ⚠️ Security warnings (if any)
+- 📝 Settings file written/updated
+
+## Rules
+
+- Start with minimal permissions
+- Add only what's detected as needed
+- Flag any security concerns
+- Don't overwrite existing custom settings without confirmation

--- a/coding-plugin/rules/bun-native.md
+++ b/coding-plugin/rules/bun-native.md
@@ -1,0 +1,97 @@
+# Bun Native APIs
+
+> Bun 1.3+ native APIs - prefer over npm packages
+
+## Bun.sql (PostgreSQL)
+
+| Instead of               | Use                             |
+| ------------------------ | ------------------------------- |
+| `pg` / `postgres`        | `import { sql } from "bun:sql"` |
+| Connection pool setup    | Built-in connection pooling     |
+| `client.query(text, [])` | `sql\`SELECT \* FROM t\``       |
+
+```typescript
+import { sql } from "bun:sql";
+
+// Parameterized (safe)
+const users = await sql`SELECT * FROM users WHERE id = ${userId}`;
+
+// Transactions
+await sql.begin(async (tx) => {
+  await tx`INSERT INTO logs (msg) VALUES (${"started"})`;
+  await tx`UPDATE users SET active = true WHERE id = ${id}`;
+});
+```
+
+**Rule:** Use tagged template literals for automatic parameterization.
+
+## Bun.redis
+
+| Instead of | Use                                 |
+| ---------- | ----------------------------------- |
+| `ioredis`  | `import { redis } from "bun:redis"` |
+| `redis`    | Built-in Redis client               |
+
+```typescript
+import { redis } from "bun:redis";
+
+await redis.set("key", "value");
+const val = await redis.get("key");
+await redis.del("key");
+```
+
+## Bun.S3
+
+| Instead of           | Use                           |
+| -------------------- | ----------------------------- |
+| `@aws-sdk/client-s3` | `import { S3 } from "bun:s3"` |
+| `aws-sdk`            | Built-in S3 client            |
+
+```typescript
+import { S3 } from "bun:s3";
+
+const s3 = new S3({
+  bucket: "my-bucket",
+  region: "eu-west-1",
+});
+
+// Upload
+await s3.put("file.txt", "content");
+
+// Download
+const content = await s3.get("file.txt");
+
+// Delete
+await s3.delete("file.txt");
+```
+
+## Bun.serve()
+
+| Instead of  | Use                  |
+| ----------- | -------------------- |
+| `express`   | `Bun.serve()`        |
+| `fastify`   | Built-in HTTP server |
+| `node:http` | Native Bun server    |
+
+```typescript
+Bun.serve({
+  port: 3000,
+  fetch(req) {
+    const url = new URL(req.url);
+    if (url.pathname === "/health") {
+      return new Response("ok");
+    }
+    return new Response("Not found", { status: 404 });
+  },
+});
+```
+
+## Migration Checklist
+
+When setting up new Bun projects:
+
+- [ ] Use `bun:sql` instead of `pg`/`postgres` for PostgreSQL
+- [ ] Use `bun:redis` instead of `ioredis`/`redis`
+- [ ] Use `bun:s3` instead of AWS SDK for S3 operations
+- [ ] Use `Bun.serve()` for simple HTTP servers
+- [ ] Keep Next.js for full-stack apps (don't replace with Bun.serve)

--- a/coding-plugin/rules/gcp-safety.md
+++ b/coding-plugin/rules/gcp-safety.md
@@ -1,0 +1,92 @@
+# GCP Safety Rules
+
+> Prevent accidental resource deletion and billing surprises
+
+## Deletion Protection
+
+**NEVER delete GCP resources without explicit user approval.**
+
+### Prohibited Without Approval
+
+| Resource Type       | Command                           | Risk Level |
+| ------------------- | --------------------------------- | ---------- |
+| Cloud Run services  | `gcloud run services delete`      | 🔴 High    |
+| Cloud SQL instances | `gcloud sql instances delete`     | 🔴 High    |
+| GCS buckets         | `gsutil rm -r gs://`              | 🔴 High    |
+| Compute instances   | `gcloud compute instances delete` | 🔴 High    |
+| IAM policies        | `gcloud iam ... remove`           | 🔴 High    |
+| Secrets             | `gcloud secrets delete`           | 🟡 Medium  |
+| Container images    | `gcloud artifacts docker delete`  | 🟡 Medium  |
+
+### Before Any Deletion
+
+1. **Ask user explicitly**: "Delete [resource]? This cannot be undone."
+2. **Require "yes" confirmation** in user response
+3. **Never batch delete** without listing each resource
+
+```bash
+# ❌ NEVER do this automatically
+gcloud run services delete my-service --quiet
+
+# ✅ Always ask first, then execute with confirmation
+gcloud run services delete my-service
+# (prompts for confirmation)
+```
+
+## Billing Safety
+
+### Cost Alerts
+
+Before deploying to production, verify:
+
+- [ ] Budget alerts configured
+- [ ] Billing account linked
+- [ ] Resource quotas set
+
+### Resource Sizing
+
+| Environment | CPU | Memory | Min Instances |
+| ----------- | --- | ------ | ------------- |
+| Staging     | 1   | 512Mi  | 0             |
+| Production  | 2   | 1Gi    | 1             |
+
+**Rule:** Start small, scale up based on metrics.
+
+## Environment Separation
+
+| Check           | Staging       | Production                 |
+| --------------- | ------------- | -------------------------- |
+| Project ID      | `*-staging`   | `*-prod` or `*-production` |
+| Service account | Limited roles | Minimal required roles     |
+| VPC             | Separate      | Isolated                   |
+
+**Rule:** Never deploy to production without explicit "production" or "prod" in command.
+
+## IAM Safety
+
+### Prohibited Actions
+
+- Granting `roles/owner` programmatically
+- Removing billing admin access
+- Modifying organization policies
+
+### Safe Patterns
+
+```bash
+# ✅ Service-specific, minimal role
+gcloud run services add-iam-policy-binding SERVICE \
+  --member="serviceAccount:SA" \
+  --role="roles/run.invoker"
+
+# ❌ Too broad
+gcloud projects add-iam-policy-binding PROJECT \
+  --member="user:EMAIL" \
+  --role="roles/editor"
+```
+
+## Flags
+
+- Any `delete` command without user confirmation
+- `--quiet` or `-q` flags that skip confirmations
+- Production deployments without explicit approval
+- IAM changes granting broad permissions


### PR DESCRIPTION
## Summary
- New rules for Bun 1.3 native APIs and GCP safety
- New commands for project init and deployment
- Settings audit command for permissions generation

## New Files

**Rules:**
- `bun-native.md` - Bun.sql, Bun.redis, Bun.S3, Bun.serve()
- `gcp-safety.md` - No deletions without explicit approval

**Commands:**
- `bun-init` - Initialize Bun + Next.js + Shadcn project
- `bun-deploy-staging` - Deploy to GCP Cloud Run staging
- `bun-deploy-production` - Deploy to production (requires "yes")
- `settings-audit` - Generate .claude/settings.json permissions

🤖 Generated with [Claude Code](https://claude.ai/code)